### PR TITLE
Corrections to Readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,7 @@ _{{ packagename }}_ is intended to provide functions to compare the outcomes of 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![R-CMD-check](https://github.com/{{ gh_repo }}/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/{{ gh_repo }}/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/{{ gh_repo }}/branch/main/graph/badge.svg)](https://app.codecov.io/gh/{{ gh_repo }}?branch=main)
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![CRAN status](https://www.r-pkg.org/badges/version/{{ packagename }})](https://CRAN.R-project.org/package={{ packagename }})
 <!-- badges: end -->
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,36 +12,35 @@ knitr::opts_chunk$set(
 )
 ```
 
-# {{ packagename }} Compare epidemic scenarios
+# {{ packagename }}: Compare epidemic scenarios
 <!-- <img src="man/figures/logo.png" align="right" width="130"/> -->
 
-{{ packagename }} is intended to provide functions to compare the outcomes of epidemic modelling simulations. This package is still a work in progress.
+_{{ packagename }}_ is intended to provide functions to compare the outcomes of epidemic modelling simulations. This package is still a work in progress.
 
 <!-- badges: start -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![R-CMD-check](https://github.com/{{ gh_repo }}/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/{{ gh_repo }}/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/{{ gh_repo }}/branch/main/graph/badge.svg)](https://app.codecov.io/gh/{{ gh_repo }}?branch=main)
-[![CRAN status](https://www.r-pkg.org/badges/version/{{ gh_repo }})](https://CRAN.R-project.org/package={{ gh_repo }})
+[![CRAN status](https://www.r-pkg.org/badges/version/{{ packagename }})](https://CRAN.R-project.org/package={{ packagename }})
 <!-- badges: end -->
 
 ## Installation
 
-You can install the development version of {{ packagename }} from
-[GitHub](https://github.com/) with:
+You can install the development version of _{{ packagename }}_ from [GitHub](https://github.com/) with:
 
-``` r
+```r
 # install.packages("remotes")
 remotes::install_github("{{ gh_repo }}")
 ```
 
 ## Help 
 
-To report a bug please open an [issue](https://github.com/epiverse-trace/{{ gh_repo }}/issues/new/choose).
+To report a bug please open an [issue](https://github.com/{{ gh_repo }}/issues/new/choose).
 
 ## Contribute
 
-Contributions to _{{ gh_repo }}_ are welcomed. Please follow the [package contributing guide](https://github.com/epiverse-trace/{{ gh_repo }}/blob/main/.github/CONTRIBUTING.md).
+Contributions to _{{ packagename }}_ are welcomed. Please follow the [package contributing guide](https://github.com/{{ gh_repo }}/blob/main/.github/CONTRIBUTING.md).
 
 ## Code of conduct
 
-Please note that the _{{ gh_repo }}_ project is released with a [Contributor Code of Conduct](https://github.com/epiverse-trace/.github/blob/main/CODE_OF_CONDUCT.md). By contributing to this project, you agree to abide by its terms.
+Please note that the _{{ packagename }}_ project is released with a [Contributor Code of Conduct](https://github.com/epiverse-trace/.github/blob/main/CODE_OF_CONDUCT.md). By contributing to this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
-# scenarios Compare epidemic scenarios
+# scenarios: Compare epidemic scenarios
 
 <!-- <img src="man/figures/logo.png" align="right" width="130"/> -->
 
-scenarios is intended to provide functions to compare the outcomes of
+*scenarios* is intended to provide functions to compare the outcomes of
 epidemic modelling simulations. This package is still a work in
 progress.
 
@@ -15,12 +15,12 @@ MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/
 [![Codecov test
 coverage](https://codecov.io/gh/epiverse-trace/scenarios/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/scenarios?branch=main)
 [![CRAN
-status](https://www.r-pkg.org/badges/version/epiverse-trace/scenarios)](https://CRAN.R-project.org/package=epiverse-trace/scenarios)
+status](https://www.r-pkg.org/badges/version/scenarios)](https://CRAN.R-project.org/package=scenarios)
 <!-- badges: end -->
 
 ## Installation
 
-You can install the development version of scenarios from
+You can install the development version of *scenarios* from
 [GitHub](https://github.com/) with:
 
 ``` r
@@ -31,17 +31,17 @@ remotes::install_github("epiverse-trace/scenarios")
 ## Help
 
 To report a bug please open an
-[issue](https://github.com/epiverse-trace/epiverse-trace/scenarios/issues/new/choose).
+[issue](https://github.com/epiverse-trace/scenarios/issues/new/choose).
 
 ## Contribute
 
-Contributions to *epiverse-trace/scenarios* are welcomed. Please follow
-the [package contributing
-guide](https://github.com/epiverse-trace/epiverse-trace/scenarios/blob/main/.github/CONTRIBUTING.md).
+Contributions to *scenarios* are welcomed. Please follow the [package
+contributing
+guide](https://github.com/epiverse-trace/scenarios/blob/main/.github/CONTRIBUTING.md).
 
 ## Code of conduct
 
-Please note that the *epiverse-trace/scenarios* project is released with
-a [Contributor Code of
+Please note that the *scenarios* project is released with a [Contributor
+Code of
 Conduct](https://github.com/epiverse-trace/.github/blob/main/CODE_OF_CONDUCT.md).
 By contributing to this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/
 [![R-CMD-check](https://github.com/epiverse-trace/scenarios/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/scenarios/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/epiverse-trace/scenarios/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/scenarios?branch=main)
+[![Project Status: WIP – Initial development is in progress, but there
+has not yet been a stable, usable release suitable for the
+public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/scenarios)](https://CRAN.R-project.org/package=scenarios)
 <!-- badges: end -->


### PR DESCRIPTION
This PR makes corrections to the Readme, with the `packagename` tag used correctly in place of `gh_repo`, as well as some basic formatting.