### PR TITLE
Remove covr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Imports:
     glue,
     jsonlite
 Suggests: 
-    covr,
     epidemics (>= 0.1.0),
     knitr,
     bookdown,


### PR DESCRIPTION
The same way we don't include pkgdown in `Suggests`, we shouldn't include covr, which is only used as part of a user-invisible development process. This also removes some of the reverse dependency checking burden for this package.