### PR TITLE
Fix ORCID links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,21 +8,21 @@ Authors@R:
             family = "Gupte",
             role = c("aut", "cre", "cph"),
             email = "pratik.gupte@lshtm.ac.uk",
-            comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819")
+            comment = c(ORCID = "0000-0001-5294-7819")
         ),
         person(
             given = "Rosalind",
             family = "Eggo",
             role = c("aut", "cph"),
             email = "rosalind.eggo@lshtm.ac.uk",
-            comment = c(ORCID = "https://orcid.org/0000-0002-0362-6717")
+            comment = c(ORCID = "0000-0002-0362-6717")
         ),
         person(
             given = "Edwin",
             family = "Van Leeuwen",
             role = c("aut", "cph"),
             email = "edwin.vanleeuwen@ukhsa.gov.uk",
-            comment = c(ORCID = "https://orcid.org/0000-0002-2383-5305")
+            comment = c(ORCID = "0000-0002-2383-5305")
         )
     )
 Description: Compare epidemic scenarios such as those from the 'finalsize' package.


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126